### PR TITLE
Update Audi-SQ7 generations: Add complete generation information from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi SQ7
 
+This repository contains signal set configurations for the Audi SQ7, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi SQ7.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,21 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q7"
+
+generations:
+  - name: "First Generation"
+    start_year: 2016
+    end_year: 2020
+    platform_code: "4M"
+    description: "Audi SQ7 based on second-generation Q7 platform. Powered by 4.0L V8 twin-turbo diesel engine producing 435 PS and 900 Nm of torque."
+
+  - name: "First Generation (2020 Facelift)"
+    start_year: 2020
+    end_year: 2024
+    platform_code: "4M"
+    description: "Facelifted SQ7 with updated styling and new TFSI petrol engine option. Diesel version produces 429-650 BHP. TFSI petrol variant produces 500 bhp and 770 Nm of torque."
+
+  - name: "First Generation (2025 Facelift)"
+    start_year: 2025
+    end_year: null
+    platform_code: "4M"
+    description: "Second facelift for SQ7 with enhanced front and rear headlight design, HD Matrix LED headlights with Laser high-beam, and OLED rear lights."


### PR DESCRIPTION
- Created generations.yaml with three generations based on Q7 platform variants
- First generation (2016-2020): SQ7 TDI with 4.0L V8 twin-turbo diesel (435 PS, 900 Nm)
- First generation 2020 facelift (2020-2024): Updated styling with TDI and new TFSI petrol options
- First generation 2025 facelift (2025-present): Enhanced LED headlights and OLED rear lights
- Updated README.md with standard vehicle documentation template
- Reference: Wikipedia Audi Q7 article documents SQ7 as performance variant of Q7 platform

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
